### PR TITLE
Edition field edited to support commercial version

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,8 +5,8 @@
 
 _pkgname="binaryninja"
 _branch="stable"
-_edition="personal"
-pkgname="${_pkgname}-${_edition}"
+_edition="-personal"
+pkgname="${_pkgname}${_edition}"
 [[ "${_branch}" != "stable" ]] && pkgname="${pkgname}-${_branch}"
 pkgdesc="Binary Ninja is a binary multi-tool and reversing platform"
 url="https://binary.ninja"
@@ -26,10 +26,10 @@ depends=(
 )
 # https://binary.ninja/recover/
 source=(
-	"file://BinaryNinja-${_edition}.zip"
+	"file://BinaryNinja${_edition}.zip"
 	"binaryninja.png"
 )
-_hash=$(curl -s https://binary.ninja/js/hashes.js | perl -pe "s/.*Ninja-${_edition}.zip\":\s\"([\da-f]+)\".*/\$1/g")
+_hash=$(curl -s https://binary.ninja/js/hashes.js | perl -pe "s/.*Ninja${_edition}.zip\":\s\"([\da-f]+)\".*/\$1/g")
 sha256sums=(
 	"${_hash}"
 	'ac2e652f617d5ef8aaa34a5113164f51f3f673c872a635d29c93878a00650bf8'


### PR DESCRIPTION
In this way another PKGBUILD can be created in order to support the commercial version too. In this way both PKGBUILDS would be identical except for the `_edition` field.

I've used this PR's PKGBUILD to test the installation of a commercial build. It works by setting `_edition=""`.

